### PR TITLE
390 자판 겹받침을 낱자 조합으로도 입력 가능하게 수정

### DIFF
--- a/NavilIME/Automata/Keyboard390.swift
+++ b/NavilIME/Automata/Keyboard390.swift
@@ -89,11 +89,16 @@ class Keyboard390 : Keyboard {
                 
             // 겹받침
             "xq":Jongsung.Kiyeoksios,  // ᆪ
-            "s1":Jongsung.Nieuncieuc,  // ᆬ
+            "s1":Jongsung.Nieunhieuh,  // ᆭ  ㄴ+ㅎ (전용키 S)
+            "s!":Jongsung.Nieuncieuc,  // ᆬ  ㄴ+ㅈ
             "w3":Jongsung.Rieulpieup,  // ᆲ
             "wq":Jongsung.Rieulsios,   // ᆳ
             "wW":Jongsung.Rieulthieuth,// ᆴ
             "wQ":Jongsung.Rieulphieuph,// ᆵ
+            // 전용 키(D/C/V)가 따로 있지만, 낱자를 차례로 눌러서도 조합돼야 함
+            "wx":Jongsung.Rieulkiyeok, // ᆰ  ㄹ+ㄱ (전용키 D)
+            "wz":Jongsung.Rieulmieum,  // ᆱ  ㄹ+ㅁ (전용키 C)
+            "w1":Jongsung.Rieulhieuh,  // ᆶ  ㄹ+ㅎ (전용키 V)
         ]
         
         // 기타 기호, 숫자 레이아웃

--- a/NavilIME/Automata/Testcases.swift
+++ b/NavilIME/Automata/Testcases.swift
@@ -403,6 +403,52 @@ class Test390 : TestCase {
         self.test_debug(hangul: hangul, t: "input", ch: "v", expect_commit: ["uvX"], expect_preedit: ["XvX"])
         self.test_debug(hangul: hangul, t: "input", ch: "v", expect_commit: ["XvX"], expect_preedit: ["XvX"])
     }
+
+    // 겹받침을 전용 키뿐 아니라 낱자를 차례로 눌러서도 조합할 수 있어야 한다.
+    // (ㄺ/ㄻ/ㅀ 조합 경로 누락, ㄴ+ㅎ이 ㄵ으로 잘못 매핑됐던 버그 회귀 방지)
+    func run_jongsung_combo() {
+        let hangul = Hangul()
+        hangul.Start(type: 390)
+
+        print("========390 겹받침 조합===========")
+
+        // 싫어 : ㅅㅣ + (ㄹ받침 w + ㅎ받침 1 = ㅀ) + ㅇㅓ
+        self.test_debug(hangul: hangul, t: "input", ch: "n", expect_commit: [], expect_preedit: ["nXX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "d", expect_commit: [], expect_preedit: ["ndX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "w", expect_commit: [], expect_preedit: ["ndw"])
+        self.test_debug(hangul: hangul, t: "input", ch: "1", expect_commit: [], expect_preedit: ["ndw1"])
+        self.test_debug(hangul: hangul, t: "input", ch: "j", expect_commit: ["ndw1"], expect_preedit: ["jXX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "t", expect_commit: [], expect_preedit: ["jtX"])
+        self.test_debug(hangul: hangul, t: "flush", ch: "", expect_commit: ["jtX"], expect_preedit: [])
+
+        // 흙 : ㅎㅡ + (ㄹ받침 w + ㄱ받침 x = ㄺ)
+        self.test_debug(hangul: hangul, t: "input", ch: "m", expect_commit: [], expect_preedit: ["mXX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "g", expect_commit: [], expect_preedit: ["mgX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "w", expect_commit: [], expect_preedit: ["mgw"])
+        self.test_debug(hangul: hangul, t: "input", ch: "x", expect_commit: [], expect_preedit: ["mgwx"])
+        self.test_debug(hangul: hangul, t: "flush", ch: "", expect_commit: ["mgwx"], expect_preedit: [])
+
+        // 삶 : ㅅㅏ + (ㄹ받침 w + ㅁ받침 z = ㄻ)
+        self.test_debug(hangul: hangul, t: "input", ch: "n", expect_commit: [], expect_preedit: ["nXX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "f", expect_commit: [], expect_preedit: ["nfX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "w", expect_commit: [], expect_preedit: ["nfw"])
+        self.test_debug(hangul: hangul, t: "input", ch: "z", expect_commit: [], expect_preedit: ["nfwz"])
+        self.test_debug(hangul: hangul, t: "flush", ch: "", expect_commit: ["nfwz"], expect_preedit: [])
+
+        // 많 : ㅁㅏ + (ㄴ받침 s + ㅎ받침 1 = ㄶ)
+        self.test_debug(hangul: hangul, t: "input", ch: "i", expect_commit: [], expect_preedit: ["iXX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "f", expect_commit: [], expect_preedit: ["ifX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "s", expect_commit: [], expect_preedit: ["ifs"])
+        self.test_debug(hangul: hangul, t: "input", ch: "1", expect_commit: [], expect_preedit: ["ifs1"])
+        self.test_debug(hangul: hangul, t: "flush", ch: "", expect_commit: ["ifs1"], expect_preedit: [])
+
+        // 앉 : ㅇㅏ + (ㄴ받침 s + ㅈ받침 ! = ㄵ)
+        self.test_debug(hangul: hangul, t: "input", ch: "j", expect_commit: [], expect_preedit: ["jXX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "f", expect_commit: [], expect_preedit: ["jfX"])
+        self.test_debug(hangul: hangul, t: "input", ch: "s", expect_commit: [], expect_preedit: ["jfs"])
+        self.test_debug(hangul: hangul, t: "input", ch: "!", expect_commit: [], expect_preedit: ["jfs!"])
+        self.test_debug(hangul: hangul, t: "flush", ch: "", expect_commit: ["jfs!"], expect_preedit: [])
+    }
 }
 
 class Test002 : TestCase {


### PR DESCRIPTION
## 문제

세벌식 390에서 일부 겹받침이 **전용 키로만** 입력되고, 낱자를 차례로 눌러 조합하면 깨졌습니다.

- `싫어`를 `ㅅ ㅣ ㄹ받침 ㅎ받침 ㅇ ㅓ` 순서로 입력하면 `실엏`이 됩니다. ㅀ이 조합되지 않아 ㅎ이 다음 글자로 넘어가 버립니다. ㅀ 전용 키(`V`)로만 입력 가능했습니다.
- 같은 증상이 ㄺ(흙), ㄻ(삶)에도 있습니다 — 전용 키 `D`/`C`로만 가능.
- ㄴ받침+ㅎ받침(`s1`)이 ㄶ이 아니라 **ㄵ으로 잘못 매핑**돼 있어 `많/않/끊` 등이 깨집니다.

## 원인

`Keyboard390`의 `jongsung_layout`에서, 전용 키가 따로 있는 겹받침(ㄺ/ㄻ/ㅀ)의 **낱자 조합 항목이 누락**돼 있었습니다. `jongsung_proc`은 사전에 등록된 키 조합으로만 겹받침을 만들기 때문에, 조합 경로가 없으면 결합에 실패하고 앞 글자가 확정돼 버립니다. (다른 겹받침 ㄳㄼㄽㄾㄿ은 조합 항목이 있어 정상 동작) 또한 `s1`(ㄴ받침+ㅎ받침)의 값이 `Nieunhieuh`(ㄶ)가 아니라 `Nieuncieuc`(ㄵ)으로 잘못 들어가 있었습니다.

## 수정

- `wx`→ㄺ, `wz`→ㄻ, `w1`→ㅀ 조합 경로 추가 (각각 전용 키 `D`/`C`/`V`와 동일 결과)
- `s1`을 ㄵ→**ㄶ**으로 바로잡음
- ㄵ을 올바른 조합 `s!`(ㄴ받침+ㅈ받침)으로 추가 — 이전엔 `s1`(ㅎ키)로 입력되던 것을 정상 키로 이동
- 318·두벌식은 이미 이 겹받침들을 낱자 조합으로 지원하고 있어 동작을 일치시켰습니다. 세벌식은 초성/종성 키가 분리돼 있어 이 조합들은 겹받침 외 다른 해석이 없습니다(도깨비불 충돌 없음).

## 테스트

`Test390`에 회귀 케이스 추가 (싫어 / 흙 / 삶 / 많 / 앉). 기존 `Test390` 케이스와 함께 전부 통과 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
