### PR TITLE
IMK 라이프사이클 타이밍에 의한 입력기 크래시 수정

### DIFF
--- a/NavilIME/NavilIMEInputController.swift
+++ b/NavilIME/NavilIMEInputController.swift
@@ -24,16 +24,22 @@ open class NavilIMEInputController: IMKInputController {
     
     override open func deactivateServer(_ sender: Any!) {
         super.deactivateServer(sender)
-        
+
         PrintLog.shared.Log(log: "Server deactivating")
-        
+
+        guard self.hangul != nil else { return }
         self.hangul.Flush()
         self.update_display(client: sender)
-        
+
         self.hangul.Stop()
+        // Stop()은 automata만 nil로 만들고 hangul 객체는 남아서, 이 뒤에 또
+        // commitComposition이 오면 Flush()의 강제 언래핑에서 크래시난다.
+        // hangul 자체를 nil로 만들어 아래 가드들이 실제로 막게 한다.
+        self.hangul = nil
     }
-    
+
     override open func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
+        guard self.hangul != nil else { return false }
         if OptHandler.shared.Is_han_eng_changed(keycode: event.keyCode, modi: event.modifierFlags) {
             self.hangul.ToggleSuspend()
             self.commitComposition(sender)
@@ -172,6 +178,9 @@ open class NavilIMEInputController: IMKInputController {
      */
     override open func commitComposition(_ sender: Any!) {
         PrintLog.shared.Log(log: "Commit Composition")
+        // IMK가 activateServer(=hangul 초기화) 전에 commitComposition을 호출할 때가 있어
+        // self.hangul 이 nil이면 강제 언래핑으로 크래시난다 → 가드로 방지.
+        guard self.hangul != nil else { return }
         self.hangul.Flush()
         self.update_display(client: sender)
     }
@@ -227,7 +236,7 @@ open class NavilIMEInputController: IMKInputController {
             PrintLog.shared.Log(log: "Selected Keyboard: \(kbd.title)")
             if kbd.tag == OptHandler.shared.opt_menu_tag {
                 PrintLog.shared.Log(log: "This is Option: \(kbd.title)")
-                self.hangul.Flush()
+                self.hangul?.Flush()
                 OptHandler.shared.Open_opt_window(sender)
                 return
             }
@@ -238,9 +247,9 @@ open class NavilIMEInputController: IMKInputController {
             kbd.state = NSControl.StateValue.on
             
             // 바꾼 한글 자판을 즉시 적용
-            self.hangul.Flush()
-            self.hangul.Stop()
-            self.hangul.Start(type: HangulMenu.shared.selected_keyboard)
+            self.hangul?.Flush()
+            self.hangul?.Stop()
+            self.hangul?.Start(type: HangulMenu.shared.selected_keyboard)
         } else {
             PrintLog.shared.Log(log: "Not NSMenuItem????")
         }


### PR DESCRIPTION
## 증상

입력기가 간헐적으로 뻗어서(크래시) 그 순간부터 한글이 입력되지 않고 영문 raw 키가 그대로 들어가는 증상이 있습니다. 닫힌 이슈 #9(이모지 후 뻗음), #12(키보드 전환 시 비활성), #16(간헐적 뻗음, 로그 제공)과 같은 계열로 추정됩니다.

## 원인

크래시 리포트(`~/Library/Logs/DiagnosticReports/NavilIME-*.ips`)에서 확인한 폴팅 프레임:

```
Swift runtime failure: Unexpectedly found nil while implicitly unwrapping an Optional value
NavilIMEInputController.commitComposition(_:)
@objc NavilIMEInputController.activateServer(_:)
-[_IMKServerLegacy commitCompositionWithReply:]_block_invoke
```

두 가지 타이밍 구멍이 있습니다.

1. IMK가 `activateServer`(= `self.hangul` 초기화) **전에** `commitComposition`/`handle`을 호출하는 경우가 있습니다 (앱 전환·포커스 변경 시). 이때 `var hangul:Hangul!` 강제 언래핑으로 크래시.
2. `deactivateServer`의 `Stop()`은 `automata`만 nil로 만들고 `hangul` 객체는 남깁니다. deactivate 이후 `commitComposition`이 한 번 더 오면 `Flush()`의 `self.automata!.run()`에서 크래시.

## 수정

- `handle` / `commitComposition` / `deactivateServer`에 `guard self.hangul != nil` 추가
- `deactivateServer`에서 `Stop()` 후 `self.hangul = nil`로 정리해 가드가 2번 케이스도 실제로 막게 함
- `select_menu`는 옵셔널 체이닝으로 변경

입력기 한글 처리 로직에는 변화가 없습니다. 수정 후 같은 사용 패턴에서 크래시 리포트가 더 발생하지 않는 것을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
