### PR TITLE
텔레그램에서 한글 조합 중 엔터가 첫 타에 전송되지 않는 문제 수정 (직접 삽입 모드)

### DIFF
--- a/NavilIME/Automata/Hangul.swift
+++ b/NavilIME/Automata/Hangul.swift
@@ -278,6 +278,21 @@ class Hangul {
         self.automata!.current = []
     }
 
+    // 조합 중인 낱자 입력 개수
+    func InputCount() -> Int {
+        return self.automata?.current.count ?? 0
+    }
+
+    // 조합 중인 입력을 커밋하지 않고 조용히 버린다.
+    // (직접 삽입 모드에서 앱이 조합 글자를 이미 가져가 버린 경우 등)
+    func Discard() {
+        self.automata?.current = []
+        self.committed = []
+        self.preediting = []
+        self.debug_commit = []
+        self.debug_preedit = []
+    }
+
     func GetPreedit() -> [unichar] {
         let ret:[unichar] = self.preediting
         self.preediting = []

--- a/NavilIME/NavilIMEInputController.swift
+++ b/NavilIME/NavilIMEInputController.swift
@@ -13,18 +13,41 @@ open class NavilIMEInputController: IMKInputController {
     let shift_key_code:String = "ASDFHGZXCV\tBQWERYT!@#$^%+(&_*)}OU{IP\tLJ\"K:|<?NM>\t ~"
     
     var hangul:Hangul!
-    
+
+    /*
+     텔레그램처럼 keyDown 오버라이드에서 `엔터 && !hasMarkedText()` 로 전송을 판정하는 앱은
+     그 판정이 입력기가 이벤트를 받기 전에 끝난다. 그래서 marked text 방식으로 조합하는 한
+     조합 중 엔터는 절대 첫 타에 전송되지 않는다 (엔터 두 번 문제).
+     이 앱들에서는 시스템 한글 입력기처럼 marked text 없이 조합한다:
+     조합 중 글자를 실제 텍스트로 즉시 넣고, 조합이 진행되면 insertText(replacementRange:)로
+     직전 글자를 교체한다. (Apple 한글 IME, SokIM DirectStrategy, hangeul_ime와 같은 방식)
+     주의: 이 목록에 앱을 추가하려면 그 앱이 selectedRange()와 attributedSubstring(from:)을
+     제대로 지원해야 한다. (커서 위치를 못 읽으면 교체 범위를 계산할 수 없다)
+     */
+    static let direct_insert_clients:Set<String> = ["ru.keepcoder.Telegram"]
+
+    func is_direct(_ client:Any!) -> Bool {
+        guard let disp = client as? IMKTextInput else { return false }
+        return NavilIMEInputController.direct_insert_clients.contains(disp.bundleIdentifier() ?? "")
+    }
+
+    // 직접 삽입 모드 상태: 화면에 넣어둔 조합 중 글자와, 삽입 직후의 기대 커서 위치
+    var direct_pending:String = ""
+    var direct_expected_loc:Int = -1
+
     override open func activateServer(_ sender: Any!) {
         super.activateServer(sender)
-        
+
         PrintLog.shared.Log(log: "Server Activated")
         self.hangul = Hangul()
         self.hangul.Start(type: HangulMenu.shared.selected_keyboard)
+        self.direct_pending = ""
+        self.direct_expected_loc = -1
     }
     
     override open func deactivateServer(_ sender: Any!) {
         super.deactivateServer(sender)
-
+        
         PrintLog.shared.Log(log: "Server deactivating")
 
         guard self.hangul != nil else { return }
@@ -34,10 +57,12 @@ open class NavilIMEInputController: IMKInputController {
         self.hangul.Stop()
         // Stop()은 automata만 nil로 만들고 hangul 객체는 남아서, 이 뒤에 또
         // commitComposition이 오면 Flush()의 강제 언래핑에서 크래시난다.
-        // hangul 자체를 nil로 만들어 아래 가드들이 실제로 막게 한다.
+        // hangul 자체를 nil로 만들어 위의 가드들이 실제로 막게 한다.
         self.hangul = nil
+        self.direct_pending = ""
+        self.direct_expected_loc = -1
     }
-
+    
     override open func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
         guard self.hangul != nil else { return false }
         if OptHandler.shared.Is_han_eng_changed(keycode: event.keyCode, modi: event.modifierFlags) {
@@ -78,22 +103,36 @@ open class NavilIMEInputController: IMKInputController {
             PrintLog.shared.Log(log: "Modikey - \(keycode) with \(flag.rawValue)")
             return false
         }
-        
+
+        // 직접 삽입 모드: 우리가 모르는 사이 필드가 바뀌었으면(엔터 전송으로 비워짐, 클릭 등)
+        // 들고 있던 조합 상태를 조용히 버리고 이번 키부터 새로 시작한다.
+        self.direct_sync_check(client: client)
+
         let enter_return = 0x24 // MacOS defined
         let tab = 0x30          // MacOS defined
         if keycode == enter_return || keycode == tab {
             PrintLog.shared.Log(log: "Enter or Tab")
-            
+
             self.hangul.Flush()
             self.update_display(client: client)
-            
+
             return false
         }
         
         let backspace = 0x33    // MacOS defined
         if keycode == backspace {
             PrintLog.shared.Log(log: "Backspace")
-            
+
+            // 직접 삽입 모드에서 마지막 낱자를 지우는 백스페이스는 앱에 그대로 넘긴다.
+            // 화면의 조합 글자는 실제 텍스트라서 앱 네이티브 백스페이스로 지우는 게 확실하다.
+            // (커스텀 텍스트뷰에서 insertText("")의 '빈 문자열 = 삭제' 동작은 보장되지 않음)
+            if self.is_direct(client) && self.hangul.InputCount() == 1 {
+                self.hangul.Discard()
+                self.direct_pending = ""
+                self.direct_expected_loc = -1
+                return false
+            }
+
             let remain = self.hangul.Backspace()
             if remain == true {
                 self.update_display(client: client, backspace: true)
@@ -146,11 +185,20 @@ open class NavilIMEInputController: IMKInputController {
         PrintLog.shared.Log(log: "C:'\(commited)' - \(commited.count) P:'\(preediting)' - \(preediting.count)")
         
         guard let disp = client as? IMKTextInput else {
+            // 클라이언트 없이 호출되면 화면의 조합 글자는 그대로 확정된 것으로 본다
+            self.direct_pending = ""
+            self.direct_expected_loc = -1
             return
         }
-        
+
         commited += additional
-        
+
+        // marked text를 쓰면 안 되는 앱은 직접 삽입 방식으로 처리
+        if self.is_direct(disp) {
+            self.direct_update(disp: disp, commited: commited, preediting: preediting)
+            return
+        }
+
         let build_count = 302
         if commited.count != 0 {
             disp.insertText(commited, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
@@ -172,6 +220,86 @@ open class NavilIMEInputController: IMKInputController {
     }
     
     /*
+     직접 삽입 모드의 화면 갱신.
+     조합 중 글자(preedit)를 marked text 대신 실제 텍스트로 넣는다.
+     직전 키에서 넣어둔 글자(direct_pending)가 있으면 그 범위를 새 내용으로 교체한다.
+     */
+    func direct_update(disp:IMKTextInput, commited:String, preediting:String) {
+        let new_text = commited + preediting
+        let old_pending = self.direct_pending
+
+        if new_text.isEmpty && old_pending.isEmpty {
+            return
+        }
+        // flush로 조합만 확정되고 화면 내용이 그대로면 클라이언트 호출 생략
+        // (이미 실제 텍스트로 들어가 있으므로 상태만 정리하면 된다)
+        // 주의: 이 비교는 commit 정규화 == preedit 정규화(normalization의 is_commit이
+        // 현재 무시됨)에 의존한다. 둘을 다르게 만들면 이 조건이 깨진다.
+        if preediting.isEmpty && new_text == old_pending {
+            self.direct_pending = ""
+            self.direct_expected_loc = -1
+            return
+        }
+
+        let sel = disp.selectedRange()
+        let old_len = old_pending.utf16.count
+        var rr = NSRange(location: NSNotFound, length: 0)
+        var base = sel.location
+
+        if old_pending.isEmpty == false && sel.location != NSNotFound && sel.location >= old_len {
+            // 직전에 넣어둔 조합 글자가 커서 앞에 그대로 있는지 확인하고 교체
+            let check_range = NSRange(location: sel.location - old_len, length: old_len)
+            let actual = disp.attributedSubstring(from: check_range)?.string
+            if actual == nil || actual == old_pending {
+                rr = check_range
+                base = sel.location - old_len
+            }
+        }
+
+        disp.insertText(new_text, replacementRange: rr)
+
+        self.direct_pending = preediting
+        if preediting.isEmpty || base == NSNotFound {
+            self.direct_expected_loc = -1
+        } else {
+            self.direct_expected_loc = base + new_text.utf16.count
+        }
+        PrintLog.shared.Log(log: "direct: '\(new_text)' rr=\(rr) pending='\(self.direct_pending)' exp=\(self.direct_expected_loc)")
+    }
+
+    /*
+     직접 삽입 모드의 일관성 검사. 키 입력 처리 전에 호출한다.
+     조합 글자가 실제 텍스트라서, 앱이 그걸 포함해 전송해 버리거나(텔레그램 엔터는
+     입력기에 전달되지 않고 keyDown에서 소비됨) 사용자가 클릭으로 커서를 옮겨도
+     입력기는 알 수 없다. 기대 커서 위치/내용과 다르면 조합 상태를 조용히 버린다.
+     */
+    func direct_sync_check(client:Any!) {
+        guard self.direct_pending.isEmpty == false,
+              let disp = client as? IMKTextInput,
+              self.is_direct(disp) else {
+            return
+        }
+        let pending_len = self.direct_pending.utf16.count
+        let sel = disp.selectedRange()
+        var stale = (sel.location == NSNotFound)
+            || (sel.length != 0)    // 선택 영역이 있으면 조합을 버리고 네이티브처럼 선택을 대체
+            || (sel.location != self.direct_expected_loc)
+            || (sel.location < pending_len)
+        if stale == false {
+            let check_range = NSRange(location: sel.location - pending_len, length: pending_len)
+            if let actual = disp.attributedSubstring(from: check_range)?.string {
+                stale = (actual != self.direct_pending)
+            }
+        }
+        if stale {
+            PrintLog.shared.Log(log: "direct: field changed externally, discard composition")
+            self.hangul?.Discard()
+            self.direct_pending = ""
+            self.direct_expected_loc = -1
+        }
+    }
+
+    /*
      입력 메서드가 이 메서드를 구현하면, 클라이언트가 컴포지션 세션을 즉시 종료하고자 할 때 호출됩니다.
      일반적인 응답은 클라이언트의 insertText 메서드를 호출한 다음 세션별 버퍼와 변수를 정리하는 것입니다.
      이 메시지를 받은 후 입력 방법은 주어진 컴포지션 세션이 완료된 것을 고려해야 합니다.
@@ -181,6 +309,8 @@ open class NavilIMEInputController: IMKInputController {
         // IMK가 activateServer(=hangul 초기화) 전에 commitComposition을 호출할 때가 있어
         // self.hangul 이 nil이면 강제 언래핑으로 크래시난다 → 가드로 방지.
         guard self.hangul != nil else { return }
+        // 직접 삽입 모드: 필드가 외부에서 바뀐 채 커밋이 오면 stale 조합부터 정리
+        self.direct_sync_check(client: sender)
         self.hangul.Flush()
         self.update_display(client: sender)
     }

--- a/NavilIME/NavilIMEInputController.swift
+++ b/NavilIME/NavilIMEInputController.swift
@@ -24,16 +24,22 @@ open class NavilIMEInputController: IMKInputController {
     
     override open func deactivateServer(_ sender: Any!) {
         super.deactivateServer(sender)
-        
+
         PrintLog.shared.Log(log: "Server deactivating")
-        
+
+        guard self.hangul != nil else { return }
         self.hangul.Flush()
         self.update_display(client: sender)
-        
+
         self.hangul.Stop()
+        // Stop()은 automata만 nil로 만들고 hangul 객체는 남아서, 이 뒤에 또
+        // commitComposition이 오면 Flush()의 강제 언래핑에서 크래시난다.
+        // hangul 자체를 nil로 만들어 아래 가드들이 실제로 막게 한다.
+        self.hangul = nil
     }
-    
+
     override open func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
+        guard self.hangul != nil else { return false }
         if OptHandler.shared.Is_han_eng_changed(keycode: event.keyCode, modi: event.modifierFlags) {
             self.hangul.ToggleSuspend()
             self.commitComposition(sender)
@@ -172,6 +178,9 @@ open class NavilIMEInputController: IMKInputController {
      */
     override open func commitComposition(_ sender: Any!) {
         PrintLog.shared.Log(log: "Commit Composition")
+        // IMK가 activateServer(=hangul 초기화) 전에 commitComposition을 호출할 때가 있어
+        // self.hangul 이 nil이면 강제 언래핑으로 크래시난다 → 가드로 방지.
+        guard self.hangul != nil else { return }
         self.hangul.Flush()
         self.update_display(client: sender)
     }
@@ -227,7 +236,7 @@ open class NavilIMEInputController: IMKInputController {
             PrintLog.shared.Log(log: "Selected Keyboard: \(kbd.title)")
             if kbd.tag == OptHandler.shared.opt_menu_tag {
                 PrintLog.shared.Log(log: "This is Option: \(kbd.title)")
-                self.hangul.Flush()
+                self.hangul?.Flush()
                 OptHandler.shared.Open_opt_window(sender)
                 return
             }
@@ -238,9 +247,9 @@ open class NavilIMEInputController: IMKInputController {
             kbd.state = NSControl.StateValue.on
             
             // 바꾼 한글 자판을 즉시 적용
-            self.hangul.Flush()
-            self.hangul.Stop()
-            self.hangul.Start(type: HangulMenu.shared.selected_keyboard)
+            self.hangul?.Flush()
+            self.hangul?.Stop()
+            self.hangul?.Start(type: HangulMenu.shared.selected_keyboard)
         } else {
             PrintLog.shared.Log(log: "Not NSMenuItem????")
         }


### PR DESCRIPTION
## 증상

텔레그램 macOS(네이티브 앱, `ru.keepcoder.Telegram`)에서 한글 조합 중 엔터를 치면 첫 엔터는 조합 확정만 되고 메시지가 전송되지 않아 **엔터를 두 번** 눌러야 합니다. macOS 기본 한글 입력기는 첫 엔터에 바로 전송됩니다.

## 원인 (텔레그램 소스에서 확인)

텔레그램의 입력 뷰는 `keyDown` 오버라이드에서 전송 여부를 판정합니다 ([ChatInputTextView.swift L1163-L1190](https://github.com/overtake/TelegramSwift/blob/579cebbf0c01fd41b712eff3647fa7f69db9665d/packages/InputView/Sources/InputView/ChatInputTextView.swift#L1163-L1190)):

```swift
if isEnterEvent(theEvent) && !self.hasMarkedText() { /* 전송 */ }
// 이 판정이 super.keyDown(= 입력기로 전달)보다 먼저 실행됨
```

즉 **전송 판정이 입력기가 엔터 이벤트를 받기 전에 끝나기 때문에**, marked text 방식으로 조합하는 한 입력기가 핸들러 안에서 무엇을 하든(커밋, setMarkedText("") 등) 첫 엔터로는 전송될 수 없습니다. 2015년 중국어 입력 문제로 들어간 게이트이고([overtake/telegram#52](https://github.com/overtake/telegram/pull/52)), 한국어 회귀는 당시 신고됐지만 방치됐습니다. 구름입력기도 같은 신고를 4번 받고 텔레그램 버그로 결론냈습니다([gureum#165](https://github.com/gureum/gureum/issues/165), [#543](https://github.com/gureum/gureum/issues/543)).

기본 입력기가 통과하는 이유: 현재 Apple 한글 IME는 **marked text를 쓰지 않습니다**. 음절을 즉시 `insertText`로 커밋하고, 조합이 진행되면 `insertText(음절, replacementRange: 직전 글자 범위)`로 교체합니다 (Chromium 팀이 실제 IME를 트레이싱한 기록: [bridged_native_widget_unittest.mm `TextInput_SimulatePhoneticIme`](https://github.com/chromium/chromium/blob/main/ui/views/cocoa/bridged_native_widget_unittest.mm)). 그래서 엔터 시점에 `hasMarkedText()`가 항상 false라 게이트를 통과합니다.

## 수정

같은 방식을 텔레그램에만 적용하는 **직접 삽입 모드**를 추가했습니다 (오픈소스 한글 입력기 [SokIM의 DirectStrategy](https://github.com/kiding/SokIM/blob/main/SokIM/DirectStrategy.swift), [hangeul_ime의 Telegram 화이트리스트](https://github.com/AlienKevin/hangeul_ime)와 같은 접근):

- `direct_insert_clients`(번들 ID 셋)에 속한 앱에서는 `setMarkedText`를 쓰지 않고, 조합 중 글자를 실제 텍스트로 즉시 넣은 뒤 조합이 진행되면 `insertText(replacementRange:)`로 직전 글자를 교체
- 교체 전에 `selectedRange()`/`attributedSubstring(from:)`으로 직전 글자가 그대로 있는지 검증
- 텔레그램이 엔터로 전송해 버린 경우(이때 입력기는 엔터 이벤트를 받지 못함)는 다음 키 입력에서 커서 위치/내용 불일치로 감지해 조합 상태를 조용히 폐기
- 마지막 낱자를 지우는 백스페이스는 앱 네이티브 동작에 위임 (커스텀 뷰에서 `insertText("")` 삭제 동작이 보장되지 않으므로)

**다른 앱은 기존 marked text 동작 그대로입니다.** (Electron/터미널 계열은 replacementRange 처리가 부실해 직접 삽입이 오히려 깨지므로, 검증된 앱만 명단에 넣는 구조)

## 테스트

텔레그램 12.6 실사용 확인: 조합 중 첫 엔터 전송, 연속 타이핑, 백스페이스, 전송 직후 타이핑(상태 폐기 경로), 조합 중 클릭, Shift+엔터 줄바꿈 모두 정상. TextEdit/VSCode 등 다른 앱 회귀 없음. 기존 Testcases 오토마타 테스트 전체 통과.

참고: 이 브랜치는 #22 (IMK 라이프사이클 크래시 수정) 위에 쌓여 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
